### PR TITLE
Implement basic auth and multi-tenant modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# TAVA Auth + Multi-Tenant Module
+
+Questo modulo fornisce le funzionalità di base di autenticazione e gestione tenant per il progetto TAVA.
+
+## Endpoint
+
+- `POST /auth/register` – registra un nuovo tenant e crea l'utente admin.
+- `POST /auth/login` – autentica un utente e restituisce un JWT contenente `tenantId` e `role`.
+
+## Configurazione
+
+Esempio di `application.yml`:
+
+```yaml
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/tava
+    username: postgres
+    password: postgres
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+jwt:
+  secret: <segreto>
+  expiration-ms: 86400000
+```
+
+## Avvio backend
+
+```bash
+cd backend
+./gradlew bootRun
+```
+
+I test unitari si eseguono con `./gradlew test`.

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,0 +1,31 @@
+plugins {
+    id 'org.springframework.boot' version '3.2.4'
+    id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
+}
+
+group = 'com.tava'
+version = '0.0.1-SNAPSHOT'
+sourceCompatibility = '21'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+    runtimeOnly 'org.postgresql:postgresql'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.mockito:mockito-core:5.11.0'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/backend/settings.gradle
+++ b/backend/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name='tava-backend'

--- a/backend/src/main/java/com/tava/TavaApplication.java
+++ b/backend/src/main/java/com/tava/TavaApplication.java
@@ -1,0 +1,11 @@
+package com.tava;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TavaApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(TavaApplication.class, args);
+    }
+}

--- a/backend/src/main/java/com/tava/auth/AuthController.java
+++ b/backend/src/main/java/com/tava/auth/AuthController.java
@@ -1,0 +1,26 @@
+package com.tava.auth;
+
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<AuthenticationResponse> register(@Valid @RequestBody RegisterTenantRequest request) {
+        return ResponseEntity.ok(authService.registerTenant(request));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<AuthenticationResponse> login(@Valid @RequestBody AuthenticationRequest request) {
+        return ResponseEntity.ok(authService.login(request));
+    }
+}

--- a/backend/src/main/java/com/tava/auth/AuthService.java
+++ b/backend/src/main/java/com/tava/auth/AuthService.java
@@ -1,0 +1,62 @@
+package com.tava.auth;
+
+import com.tava.tenant.TenantService;
+import com.tava.user.User;
+import com.tava.user.UserRepository;
+import io.jsonwebtoken.Claims;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthService {
+
+    private final TenantService tenantService;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtUtils jwtUtils;
+    private final AuthenticationManager authenticationManager;
+    private final UserDetailsService userDetailsService;
+
+    public AuthService(TenantService tenantService,
+                       UserRepository userRepository,
+                       PasswordEncoder passwordEncoder,
+                       JwtUtils jwtUtils,
+                       AuthenticationManager authenticationManager,
+                       UserDetailsService userDetailsService) {
+        this.tenantService = tenantService;
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtUtils = jwtUtils;
+        this.authenticationManager = authenticationManager;
+        this.userDetailsService = userDetailsService;
+    }
+
+    public AuthenticationResponse registerTenant(RegisterTenantRequest request) {
+        User admin = tenantService.createTenantWithAdmin(
+                request.getTenantName(),
+                request.getAdminEmail(),
+                request.getPassword()
+        );
+        String token = jwtUtils.generateToken(admin.getId(), admin.getTenantId(), admin.getRole());
+        return new AuthenticationResponse(token, admin.getId(), admin.getTenantId(), admin.getRole());
+    }
+
+    public AuthenticationResponse login(AuthenticationRequest request) {
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword())
+        );
+        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+        User user = userRepository.findByEmail(userDetails.getUsername()).orElseThrow();
+        String token = jwtUtils.generateToken(user.getId(), user.getTenantId(), user.getRole());
+        return new AuthenticationResponse(token, user.getId(), user.getTenantId(), user.getRole());
+    }
+
+    public Claims parseToken(String token) {
+        return jwtUtils.parseToken(token);
+    }
+}

--- a/backend/src/main/java/com/tava/auth/AuthenticationRequest.java
+++ b/backend/src/main/java/com/tava/auth/AuthenticationRequest.java
@@ -1,0 +1,30 @@
+package com.tava.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public class AuthenticationRequest {
+
+    @Email
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    private String password;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/backend/src/main/java/com/tava/auth/AuthenticationResponse.java
+++ b/backend/src/main/java/com/tava/auth/AuthenticationResponse.java
@@ -1,0 +1,51 @@
+package com.tava.auth;
+
+import com.tava.user.Role;
+
+import java.util.UUID;
+
+public class AuthenticationResponse {
+    private String token;
+    private UUID userId;
+    private UUID tenantId;
+    private Role role;
+
+    public AuthenticationResponse(String token, UUID userId, UUID tenantId, Role role) {
+        this.token = token;
+        this.userId = userId;
+        this.tenantId = tenantId;
+        this.role = role;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public void setUserId(UUID userId) {
+        this.userId = userId;
+    }
+
+    public UUID getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(UUID tenantId) {
+        this.tenantId = tenantId;
+    }
+
+    public Role getRole() {
+        return role;
+    }
+
+    public void setRole(Role role) {
+        this.role = role;
+    }
+}

--- a/backend/src/main/java/com/tava/auth/JwtUtils.java
+++ b/backend/src/main/java/com/tava/auth/JwtUtils.java
@@ -1,0 +1,50 @@
+package com.tava.auth;
+
+import com.tava.user.Role;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+import java.util.Map;
+import java.util.UUID;
+
+@Component
+public class JwtUtils {
+
+    private final SecretKey secretKey;
+    private final long expirationMs;
+
+    public JwtUtils(@Value("${jwt.secret}") String secret,
+                    @Value("${jwt.expiration-ms:86400000}") long expirationMs) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes());
+        this.expirationMs = expirationMs;
+    }
+
+    public String generateToken(UUID userId, UUID tenantId, Role role) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + expirationMs);
+        return Jwts.builder()
+                .setSubject(userId.toString())
+                .addClaims(Map.of(
+                        "tenantId", tenantId.toString(),
+                        "role", role.name()
+                ))
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public Claims parseToken(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/backend/src/main/java/com/tava/auth/RegisterTenantRequest.java
+++ b/backend/src/main/java/com/tava/auth/RegisterTenantRequest.java
@@ -1,0 +1,41 @@
+package com.tava.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public class RegisterTenantRequest {
+
+    @NotBlank
+    private String tenantName;
+
+    @Email
+    @NotBlank
+    private String adminEmail;
+
+    @NotBlank
+    private String password;
+
+    public String getTenantName() {
+        return tenantName;
+    }
+
+    public void setTenantName(String tenantName) {
+        this.tenantName = tenantName;
+    }
+
+    public String getAdminEmail() {
+        return adminEmail;
+    }
+
+    public void setAdminEmail(String adminEmail) {
+        this.adminEmail = adminEmail;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/backend/src/main/java/com/tava/config/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/tava/config/CustomUserDetailsService.java
@@ -1,0 +1,29 @@
+package com.tava.config;
+
+import com.tava.user.User;
+import com.tava.user.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.core.userdetails.User.UserBuilder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+        UserBuilder builder = org.springframework.security.core.userdetails.User.withUsername(user.getEmail());
+        builder.password(user.getPassword());
+        builder.roles(user.getRole().name());
+        return builder.build();
+    }
+}

--- a/backend/src/main/java/com/tava/config/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/tava/config/JwtAuthenticationFilter.java
@@ -1,0 +1,57 @@
+package com.tava.config;
+
+import com.tava.auth.JwtUtils;
+import com.tava.tenant.TenantContext;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtils jwtUtils;
+    private final UserDetailsService userDetailsService;
+
+    public JwtAuthenticationFilter(JwtUtils jwtUtils, UserDetailsService userDetailsService) {
+        this.jwtUtils = jwtUtils;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (header != null && header.startsWith("Bearer ")) {
+            String token = header.substring(7);
+            try {
+                Claims claims = jwtUtils.parseToken(token);
+                String username = claims.getSubject();
+                UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+                UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+                SecurityContextHolder.getContext().setAuthentication(auth);
+                TenantContext.setTenantId(claims.get("tenantId", String.class));
+            } catch (Exception e) {
+                SecurityContextHolder.clearContext();
+            }
+        }
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            TenantContext.clear();
+        }
+    }
+}

--- a/backend/src/main/java/com/tava/config/SecurityConfig.java
+++ b/backend/src/main/java/com/tava/config/SecurityConfig.java
@@ -1,0 +1,42 @@
+package com.tava.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.POST, "/auth/login", "/auth/register").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+}

--- a/backend/src/main/java/com/tava/tenant/Tenant.java
+++ b/backend/src/main/java/com/tava/tenant/Tenant.java
@@ -1,0 +1,32 @@
+package com.tava.tenant;
+
+import jakarta.persistence.*;
+import java.util.UUID;
+
+@Entity
+public class Tenant {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    // getters and setters
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/backend/src/main/java/com/tava/tenant/TenantContext.java
+++ b/backend/src/main/java/com/tava/tenant/TenantContext.java
@@ -1,0 +1,17 @@
+package com.tava.tenant;
+
+public class TenantContext {
+    private static final ThreadLocal<String> CURRENT_TENANT = new ThreadLocal<>();
+
+    public static void setTenantId(String tenantId) {
+        CURRENT_TENANT.set(tenantId);
+    }
+
+    public static String getTenantId() {
+        return CURRENT_TENANT.get();
+    }
+
+    public static void clear() {
+        CURRENT_TENANT.remove();
+    }
+}

--- a/backend/src/main/java/com/tava/tenant/TenantRepository.java
+++ b/backend/src/main/java/com/tava/tenant/TenantRepository.java
@@ -1,0 +1,10 @@
+package com.tava.tenant;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface TenantRepository extends JpaRepository<Tenant, UUID> {
+    Optional<Tenant> findByName(String name);
+}

--- a/backend/src/main/java/com/tava/tenant/TenantService.java
+++ b/backend/src/main/java/com/tava/tenant/TenantService.java
@@ -1,0 +1,43 @@
+package com.tava.tenant;
+
+import com.tava.user.Role;
+import com.tava.user.User;
+import com.tava.user.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class TenantService {
+
+    private final TenantRepository tenantRepository;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public TenantService(TenantRepository tenantRepository,
+                         UserRepository userRepository,
+                         PasswordEncoder passwordEncoder) {
+        this.tenantRepository = tenantRepository;
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public User createTenantWithAdmin(String tenantName, String email, String password) {
+        Tenant tenant = new Tenant();
+        tenant.setName(tenantName);
+        tenant = tenantRepository.save(tenant);
+
+        User admin = new User();
+        admin.setEmail(email);
+        admin.setUsername(email);
+        admin.setPassword(passwordEncoder.encode(password));
+        admin.setRole(Role.ADMIN);
+        admin.setTenantId(tenant.getId());
+        return userRepository.save(admin);
+    }
+
+    public Tenant findById(UUID id) {
+        return tenantRepository.findById(id).orElse(null);
+    }
+}

--- a/backend/src/main/java/com/tava/user/PasswordEncoderConfig.java
+++ b/backend/src/main/java/com/tava/user/PasswordEncoderConfig.java
@@ -1,0 +1,15 @@
+package com.tava.user;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/backend/src/main/java/com/tava/user/Role.java
+++ b/backend/src/main/java/com/tava/user/Role.java
@@ -1,0 +1,6 @@
+package com.tava.user;
+
+public enum Role {
+    ADMIN,
+    COLLABORATOR
+}

--- a/backend/src/main/java/com/tava/user/User.java
+++ b/backend/src/main/java/com/tava/user/User.java
@@ -1,0 +1,77 @@
+package com.tava.user;
+
+import jakarta.persistence.*;
+import java.util.UUID;
+
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @Column(nullable = false)
+    private UUID tenantId;
+
+    // getters and setters
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public Role getRole() {
+        return role;
+    }
+
+    public void setRole(Role role) {
+        this.role = role;
+    }
+
+    public UUID getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(UUID tenantId) {
+        this.tenantId = tenantId;
+    }
+}

--- a/backend/src/main/java/com/tava/user/UserRepository.java
+++ b/backend/src/main/java/com/tava/user/UserRepository.java
@@ -1,0 +1,10 @@
+package com.tava.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserRepository extends JpaRepository<User, UUID> {
+    Optional<User> findByEmail(String email);
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/tava
+    username: postgres
+    password: postgres
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+jwt:
+  secret: changemepleasechangemepleasechangeme
+  expiration-ms: 86400000

--- a/backend/src/test/java/com/tava/auth/AuthServiceTest.java
+++ b/backend/src/test/java/com/tava/auth/AuthServiceTest.java
@@ -1,0 +1,86 @@
+package com.tava.auth;
+
+import com.tava.tenant.TenantService;
+import com.tava.user.Role;
+import com.tava.user.User;
+import com.tava.user.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public class AuthServiceTest {
+
+    @Test
+    void testRegisterTenant() {
+        TenantService tenantService = mock(TenantService.class);
+        UserRepository userRepository = mock(UserRepository.class);
+        PasswordEncoder encoder = mock(PasswordEncoder.class);
+        JwtUtils jwtUtils = new JwtUtils("0123456789012345678901234567890123456789012345678901234567890123", 1000);
+        AuthenticationManager authenticationManager = mock(AuthenticationManager.class);
+        UserDetailsService userDetailsService = mock(UserDetailsService.class);
+
+        AuthService authService = new AuthService(tenantService, userRepository, encoder, jwtUtils, authenticationManager, userDetailsService);
+
+        User admin = new User();
+        admin.setId(UUID.randomUUID());
+        admin.setTenantId(UUID.randomUUID());
+        admin.setRole(Role.ADMIN);
+
+        when(tenantService.createTenantWithAdmin(any(), any(), any())).thenReturn(admin);
+
+        RegisterTenantRequest request = new RegisterTenantRequest();
+        request.setTenantName("test");
+        request.setAdminEmail("a@b.com");
+        request.setPassword("pass");
+
+        AuthenticationResponse response = authService.registerTenant(request);
+        assertNotNull(response.getToken());
+        assertEquals(admin.getTenantId(), response.getTenantId());
+    }
+
+    @Test
+    void testLogin() {
+        TenantService tenantService = mock(TenantService.class);
+        UserRepository userRepository = mock(UserRepository.class);
+        PasswordEncoder encoder = mock(PasswordEncoder.class);
+        JwtUtils jwtUtils = new JwtUtils("0123456789012345678901234567890123456789012345678901234567890123", 1000);
+        AuthenticationManager authenticationManager = mock(AuthenticationManager.class);
+        UserDetailsService userDetailsService = mock(UserDetailsService.class);
+
+        AuthService authService = new AuthService(tenantService, userRepository, encoder, jwtUtils, authenticationManager, userDetailsService);
+
+        User user = new User();
+        user.setId(UUID.randomUUID());
+        user.setTenantId(UUID.randomUUID());
+        user.setRole(Role.ADMIN);
+        user.setEmail("test@test.com");
+
+        UserDetails userDetails = org.springframework.security.core.userdetails.User
+                .withUsername(user.getEmail()).password("pass").roles("ADMIN").build();
+
+        Authentication auth = mock(Authentication.class);
+        when(auth.getPrincipal()).thenReturn(userDetails);
+        when(authenticationManager.authenticate(any())).thenReturn(auth);
+        when(userDetailsService.loadUserByUsername(any())).thenReturn(userDetails);
+        when(userRepository.findByEmail(any())).thenReturn(Optional.of(user));
+
+        AuthenticationRequest request = new AuthenticationRequest();
+        request.setEmail("test@test.com");
+        request.setPassword("pass");
+
+        AuthenticationResponse response = authService.login(request);
+        assertEquals(user.getTenantId(), response.getTenantId());
+    }
+}

--- a/backend/src/test/java/com/tava/tenant/TenantServiceTest.java
+++ b/backend/src/test/java/com/tava/tenant/TenantServiceTest.java
@@ -1,0 +1,38 @@
+package com.tava.tenant;
+
+import com.tava.user.Role;
+import com.tava.user.User;
+import com.tava.user.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class TenantServiceTest {
+
+    @Test
+    void testCreateTenantWithAdmin() {
+        TenantRepository tenantRepository = mock(TenantRepository.class);
+        UserRepository userRepository = mock(UserRepository.class);
+        PasswordEncoder encoder = mock(PasswordEncoder.class);
+
+        TenantService tenantService = new TenantService(tenantRepository, userRepository, encoder);
+
+        Tenant tenant = new Tenant();
+        tenant.setId(UUID.randomUUID());
+        tenant.setName("test");
+        when(tenantRepository.save(any())).thenReturn(tenant);
+
+        User adminSaved = new User();
+        when(userRepository.save(any())).thenReturn(adminSaved);
+
+        User admin = tenantService.createTenantWithAdmin("test", "mail@test.com", "pass");
+        assertNotNull(admin);
+        verify(tenantRepository).save(any());
+        verify(userRepository).save(any());
+    }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "tava-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@reduxjs/toolkit": "^2.2.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-redux": "^8.1.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2"
+  },
+  "scripts": {
+    "start": "webpack serve --mode development",
+    "build": "webpack --mode production",
+    "test": "echo 'no tests'"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,5 @@
+import LoginPage from './features/auth/LoginPage';
+
+export default function App() {
+  return <LoginPage />;
+}

--- a/frontend/src/features/auth/LoginPage.tsx
+++ b/frontend/src/features/auth/LoginPage.tsx
@@ -1,0 +1,21 @@
+import { useState } from 'react';
+import { useAuth } from './useAuth';
+
+export default function LoginPage() {
+  const { doLogin } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    doLogin(email, password);
+  };
+
+  return (
+    <form onSubmit={submit}>
+      <input value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+      <input value={password} onChange={e => setPassword(e.target.value)} type="password" placeholder="Password" />
+      <button type="submit">Login</button>
+    </form>
+  );
+}

--- a/frontend/src/features/auth/RegisterTenantPage.tsx
+++ b/frontend/src/features/auth/RegisterTenantPage.tsx
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+import { useAuth } from './useAuth';
+
+export default function RegisterTenantPage() {
+  const { doRegister } = useAuth();
+  const [tenantName, setTenantName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    doRegister(tenantName, email, password);
+  };
+
+  return (
+    <form onSubmit={submit}>
+      <input value={tenantName} onChange={e => setTenantName(e.target.value)} placeholder="Tenant name" />
+      <input value={email} onChange={e => setEmail(e.target.value)} placeholder="Admin email" />
+      <input value={password} onChange={e => setPassword(e.target.value)} type="password" placeholder="Password" />
+      <button type="submit">Register</button>
+    </form>
+  );
+}

--- a/frontend/src/features/auth/authAPI.ts
+++ b/frontend/src/features/auth/authAPI.ts
@@ -1,0 +1,19 @@
+export async function login(email: string, password: string) {
+  const res = await fetch('/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password })
+  });
+  if (!res.ok) throw new Error('Login failed');
+  return res.json();
+}
+
+export async function registerTenant(tenantName: string, adminEmail: string, password: string) {
+  const res = await fetch('/auth/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ tenantName, adminEmail, password })
+  });
+  if (!res.ok) throw new Error('Register failed');
+  return res.json();
+}

--- a/frontend/src/features/auth/authSlice.ts
+++ b/frontend/src/features/auth/authSlice.ts
@@ -1,0 +1,25 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+interface AuthState {
+  token: string | null;
+}
+
+const initialState: AuthState = {
+  token: null
+};
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    setToken(state, action) {
+      state.token = action.payload;
+    },
+    clearToken(state) {
+      state.token = null;
+    }
+  }
+});
+
+export const { setToken, clearToken } = authSlice.actions;
+export default authSlice.reducer;

--- a/frontend/src/features/auth/useAuth.ts
+++ b/frontend/src/features/auth/useAuth.ts
@@ -1,0 +1,22 @@
+import { useDispatch, useSelector } from 'react-redux';
+import { login, registerTenant } from './authAPI';
+import { setToken, clearToken } from './authSlice';
+
+export function useAuth() {
+  const dispatch = useDispatch();
+  const token = useSelector((state: any) => state.auth.token);
+
+  const doLogin = async (email: string, password: string) => {
+    const data = await login(email, password);
+    dispatch(setToken(data.token));
+  };
+
+  const doRegister = async (tenantName: string, email: string, password: string) => {
+    const data = await registerTenant(tenantName, email, password);
+    dispatch(setToken(data.token));
+  };
+
+  const logout = () => dispatch(clearToken());
+
+  return { token, doLogin, doRegister, logout };
+}

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import authReducer from './features/auth/authSlice';
+import App from './App';
+
+const store = configureStore({ reducer: { auth: authReducer } });
+
+createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <Provider store={store}>
+      <App />
+    </Provider>
+  </React.StrictMode>
+);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add Spring Boot backend with JWT auth and tenant management
- add React auth feature with login and registration pages
- include unit tests for services
- document endpoints and config snippet

## Testing
- `gradle test --console=plain --no-daemon`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ad7e2e548832a8b3b28823a3d377d