### PR TITLE
Set up React frontend with auth flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "tava-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "webpack serve --mode development",
+    "build": "webpack --mode production"
+  },
+  "dependencies": {
+    "axios": "^1.6.7",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-redux": "^8.1.2",
+    "react-router-dom": "^6.21.1",
+    "@reduxjs/toolkit": "^2.1.6"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3",
+    "ts-loader": "^9.5.1",
+    "@types/react": "^18.2.14",
+    "@types/react-dom": "^18.2.7",
+    "@types/react-redux": "^7.1.27",
+    "@types/react-router-dom": "^5.3.3",
+    "webpack": "^5.89.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TAVA</title>
+</head>
+<body>
+    <div id="root"></div>
+</body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Routes, Route, Navigate } from 'react-router-dom';
+import LoginPage from './features/auth/LoginPage';
+import RegisterTenantPage from './features/auth/RegisterTenantPage';
+import useAuth from './hooks/useAuth';
+
+const Home: React.FC = () => <div>Welcome to TAVA</div>;
+
+const PrivateRoute: React.FC<{ children: JSX.Element }> = ({ children }) => {
+  const { isAuthenticated } = useAuth();
+  return isAuthenticated ? children : <Navigate to="/login" replace />;
+};
+
+const App: React.FC = () => {
+  return (
+    <Routes>
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/register" element={<RegisterTenantPage />} />
+      <Route
+        path="/*"
+        element={
+          <PrivateRoute>
+            <Home />
+          </PrivateRoute>
+        }
+      />
+    </Routes>
+  );
+};
+
+export default App;

--- a/src/api/authAPI.ts
+++ b/src/api/authAPI.ts
@@ -1,0 +1,33 @@
+import axios from 'axios';
+import {
+  LoginRequest,
+  LoginResponse,
+  RegisterTenantRequest,
+  RegisterTenantResponse,
+} from '../types/Auth';
+
+const api = axios.create({
+  baseURL: '/api',
+});
+
+export async function login(data: LoginRequest): Promise<LoginResponse> {
+  const response = await api.post<LoginResponse>('/auth/login', data);
+  return response.data;
+}
+
+export async function fetchMe(token: string): Promise<LoginResponse> {
+  const response = await api.get<LoginResponse>('/auth/me', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return response.data;
+}
+
+export async function registerTenant(
+  data: RegisterTenantRequest
+): Promise<RegisterTenantResponse> {
+  const response = await api.post<RegisterTenantResponse>(
+    '/auth/register',
+    data
+  );
+  return response.data;
+}

--- a/src/features/auth/LoginPage.tsx
+++ b/src/features/auth/LoginPage.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import { login } from '../../api/authAPI';
+import {
+  loginStart,
+  loginSuccess,
+  loginFailure,
+} from '../../store/authSlice';
+import { AppDispatch, RootState } from '../../store';
+
+const LoginPage: React.FC = () => {
+  const dispatch: AppDispatch = useDispatch();
+  const navigate = useNavigate();
+  const status = useSelector((state: RootState) => state.auth.status);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!email || !password) {
+      setError('Email and password are required');
+      return;
+    }
+
+    try {
+      dispatch(loginStart());
+      const data = await login({ email, password });
+      localStorage.setItem('token', data.token);
+      dispatch(loginSuccess(data));
+      navigate('/');
+    } catch (err: any) {
+      dispatch(loginFailure(err.message));
+      setError('Invalid credentials');
+    }
+  };
+
+  return (
+    <div>
+      <h2>Login</h2>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <label>Email</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </div>
+        <div>
+          <label>Password</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </div>
+        {error && <p>{error}</p>}
+        <button type="submit" disabled={status === 'loading'}>
+          {status === 'loading' ? 'Logging in...' : 'Login'}
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/src/features/auth/RegisterTenantPage.tsx
+++ b/src/features/auth/RegisterTenantPage.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import { registerTenant } from '../../api/authAPI';
+import { loginSuccess } from '../../store/authSlice';
+import { AppDispatch } from '../../store';
+
+const RegisterTenantPage: React.FC = () => {
+  const dispatch: AppDispatch = useDispatch();
+  const navigate = useNavigate();
+  const [tenantName, setTenantName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!tenantName || !email || !password) {
+      setError('All fields are required');
+      return;
+    }
+
+    try {
+      const data = await registerTenant({ tenantName, email, password });
+      localStorage.setItem('token', data.token);
+      dispatch(loginSuccess(data));
+      navigate('/');
+    } catch (err: any) {
+      setError('Registration failed');
+    }
+  };
+
+  return (
+    <div>
+      <h2>Register Tenant</h2>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <label>Tenant Name</label>
+          <input
+            type="text"
+            value={tenantName}
+            onChange={(e) => setTenantName(e.target.value)}
+          />
+        </div>
+        <div>
+          <label>Email</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </div>
+        <div>
+          <label>Password</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </div>
+        {error && <p>{error}</p>}
+        <button type="submit">Register</button>
+      </form>
+    </div>
+  );
+};
+
+export default RegisterTenantPage;

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,21 @@
+import { useSelector, useDispatch } from 'react-redux';
+import { RootState, AppDispatch } from '../store';
+import { logout as logoutAction } from '../store/authSlice';
+
+export default function useAuth() {
+  const dispatch: AppDispatch = useDispatch();
+  const user = useSelector((state: RootState) => state.auth.user);
+  const token = useSelector((state: RootState) => state.auth.token);
+
+  const logout = () => {
+    localStorage.removeItem('token');
+    dispatch(logoutAction());
+  };
+
+  return {
+    user,
+    token,
+    isAuthenticated: Boolean(token),
+    logout,
+  };
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { Provider } from 'react-redux';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import store from './store';
+
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+root.render(
+  <React.StrictMode>
+    <Provider store={store}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </Provider>
+  </React.StrictMode>
+);

--- a/src/store/authSlice.ts
+++ b/src/store/authSlice.ts
@@ -1,0 +1,43 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { User } from '../types/Auth';
+
+interface AuthState {
+  user: User | null;
+  token: string | null;
+  status: 'idle' | 'loading' | 'succeeded' | 'failed';
+  error?: string;
+}
+
+const initialState: AuthState = {
+  user: null,
+  token: null,
+  status: 'idle',
+};
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    loginStart(state) {
+      state.status = 'loading';
+      state.error = undefined;
+    },
+    loginSuccess(state, action: PayloadAction<{ user: User; token: string }>) {
+      state.status = 'succeeded';
+      state.user = action.payload.user;
+      state.token = action.payload.token;
+    },
+    loginFailure(state, action: PayloadAction<string>) {
+      state.status = 'failed';
+      state.error = action.payload;
+    },
+    logout(state) {
+      state.user = null;
+      state.token = null;
+      state.status = 'idle';
+    },
+  },
+});
+
+export const { loginStart, loginSuccess, loginFailure, logout } = authSlice.actions;
+export default authSlice.reducer;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,12 @@
+import { configureStore } from '@reduxjs/toolkit';
+import authReducer from './authSlice';
+
+const store = configureStore({
+  reducer: {
+    auth: authReducer,
+  },
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;
+export default store;

--- a/src/types/Auth.ts
+++ b/src/types/Auth.ts
@@ -1,0 +1,27 @@
+export interface User {
+  id: string;
+  email: string;
+  tenant: string;
+  [key: string]: unknown;
+}
+
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  user: User;
+  token: string;
+}
+
+export interface RegisterTenantRequest {
+  tenantName: string;
+  email: string;
+  password: string;
+}
+
+export interface RegisterTenantResponse {
+  user: User;
+  token: string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "strict": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,29 @@
+const path = require('path');
+
+module.exports = {
+  entry: './src/index.tsx',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.js',
+    publicPath: '/',
+  },
+  resolve: {
+    extensions: ['.tsx', '.ts', '.js'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+      },
+    ],
+  },
+  devServer: {
+    static: {
+      directory: path.join(__dirname, 'public'),
+    },
+    historyApiFallback: true,
+    port: 3000,
+  },
+};


### PR DESCRIPTION
## Summary
- add React+TypeScript client bootstrapped with Redux Toolkit
- implement authentication slice and hook
- add login and tenant registration pages
- configure Webpack and TypeScript
- include base HTML template

## Testing
- `npx tsc --noEmit` *(fails: cannot download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685bb3f61fc0832a8082df5f18da69ac